### PR TITLE
kubernetes-controllers

### DIFF
--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: mikeq123/hipster-frontend:v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: localhost
+        - name: CURRENCY_SERVICE_ADDR
+          value: localhost
+        - name: CART_SERVICE_ADDR
+          value: localhost
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: localhost
+        - name: CHECKOUT_SERVICE_ADDR
+          value: localhost
+        - name: SHIPPING_SERVICE_ADDR
+          value: localhost
+        - name: AD_SERVICE_ADDR
+          value: localhost
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: mikeq123/hipster-frontend:v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: localhost
+        - name: CURRENCY_SERVICE_ADDR
+          value: localhost
+        - name: CART_SERVICE_ADDR
+          value: localhost
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: localhost
+        - name: CHECKOUT_SERVICE_ADDR
+          value: localhost
+        - name: SHIPPING_SERVICE_ADDR
+          value: localhost
+        - name: AD_SERVICE_ADDR
+          value: localhost

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: v0.18.1
+  name: node-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/version: v0.18.1
+    spec:
+      containers:
+      - args:
+        - --web.listen-address=127.0.0.1:9100
+        - --path.procfs=/host/proc
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        image: quay.io/prometheus/node-exporter:v0.18.1
+        name: node-exporter
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/proc
+          name: proc
+          readOnly: false
+        - mountPath: /host/sys
+          name: sys
+          readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=[$(IP)]:9100
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: node-exporter
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: mikeq123/hipster-paymentservice:v0.0.1
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: localhost
+        - name: CURRENCY_SERVICE_ADDR
+          value: localhost
+        - name: CART_SERVICE_ADDR
+          value: localhost
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: localhost
+        - name: CHECKOUT_SERVICE_ADDR
+          value: localhost
+        - name: SHIPPING_SERVICE_ADDR
+          value: localhost
+        - name: AD_SERVICE_ADDR
+          value: localhost

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: mikeq123/hipster-paymentservice:v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: localhost
+        - name: CURRENCY_SERVICE_ADDR
+          value: localhost
+        - name: CART_SERVICE_ADDR
+          value: localhost
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: localhost
+        - name: CHECKOUT_SERVICE_ADDR
+          value: localhost
+        - name: SHIPPING_SERVICE_ADDR
+          value: localhost
+        - name: AD_SERVICE_ADDR
+          value: localhost

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: mikeq123/hipster-paymentservice:v0.0.1
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: localhost
+        - name: CURRENCY_SERVICE_ADDR
+          value: localhost
+        - name: CART_SERVICE_ADDR
+          value: localhost
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: localhost
+        - name: CHECKOUT_SERVICE_ADDR
+          value: localhost
+        - name: SHIPPING_SERVICE_ADDR
+          value: localhost
+        - name: AD_SERVICE_ADDR
+          value: localhost

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: mikeq123/hipster-paymentservice:v0.0.1
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: localhost
+        - name: CURRENCY_SERVICE_ADDR
+          value: localhost
+        - name: CART_SERVICE_ADDR
+          value: localhost
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: localhost
+        - name: CHECKOUT_SERVICE_ADDR
+          value: localhost
+        - name: SHIPPING_SERVICE_ADDR
+          value: localhost
+        - name: AD_SERVICE_ADDR
+          value: localhost

--- a/kubernetes-controllers/service-account.yaml
+++ b/kubernetes-controllers/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-exporter
+  namespace: monitoring


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [*] Основное ДЗ
 - [*] Задание со *

## В процессе сделано:
 - развернут кластер с помощью kind
 - создан манифест replicaset для микросервиса frontend
 - проверено, что replicaset масштабируется ad-hock командой
 - продемострирована примитивная сущность replicaset - контроллер не смотрит что именно запущено, он просто смотрит что количество подов соответствующих селектору, такое какое нужно.
 - Собран docker-образ для микросервиса paymentservice
 - Создан манифест replicaset для микросервиса paymentservice
 - Создан deployment для микросервиса paymentservice
 - Протестировано обновление подов микросервиса paymentservice с помощью deployment'а
 - Протестирован откат обновления микросервиса
 - Реализованы сценарии обновлений blue/green и reverse rolling update
 - Протестирована работа readynessProbe
 - Продемонстрирована работа контроллера Daemonset. 
 - Дополнительные задания немного устарели.  Дефолтный манифест node-exporter предполагает, что в кластере присутствует service account monitoring/node-exporter и без нее ничего не запускается.
Также, в кластере, разворачиваемом текущей версией kind, pod'ы node-exporter благополучно запустились на всех нодах (и мастерах и воркерах) с текущей дефолтной версией манифеста daemonset. В задании, веротяно, речь шла о tolerations.
Сам манифест - https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/node-exporter-daemonset.yaml . kind version 0.8.

## Как запустить проект:
 - Для создания тестового pod'а нужно в директории kubernetes-controllers запустить команду kubectl apply -f .
 - Для проверки работоспособности - предоставить доступ к pod'у, запустив команду kubectl port-forward --address 0.0.0.0 pod/web 8000:8000

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8000

## PR checklist:
 - [*] Выставлен label с темой домашнего задания
